### PR TITLE
drivers: flash_sync_mpsl: Allow configuring time of using high priority

### DIFF
--- a/applications/nrf_desktop/Kconfig.ble
+++ b/applications/nrf_desktop/Kconfig.ble
@@ -351,6 +351,16 @@ config BT_L2CAP_TX_BUF_COUNT
 	  For an nRF Desktop device, the maximum number of L2CAP buffers
 	  is aligned to the number of outgoing ACL buffers.
 
+if SOC_FLASH_NRF_RADIO_SYNC_MPSL
+
+config SOC_FLASH_NRF_RADIO_SYNC_MPSL_NORMAL_PRIORITY_TIMEOUT_US
+	default 0
+	help
+	  Start using high MPSL timeslot priority quicker to speed up
+	  non-volatile memory operations.
+
+endif # SOC_FLASH_NRF_RADIO_SYNC_MPSL
+
 choice BT_HCI_CORE_LOG_LEVEL_CHOICE
 	default BT_HCI_CORE_LOG_LEVEL_WRN
 	help

--- a/drivers/mpsl/flash_sync/Kconfig
+++ b/drivers/mpsl/flash_sync/Kconfig
@@ -38,6 +38,17 @@ endchoice
 
 endif
 
+config SOC_FLASH_NRF_RADIO_SYNC_MPSL_NORMAL_PRIORITY_TIMEOUT_US
+	int "Timeout for normal priority MPSL request [us]"
+	depends on SOC_FLASH_NRF_RADIO_SYNC_MPSL
+	range 0 1000000
+	default 30000
+	help
+	  The flash synchronization mechanism relies on MPSL timeslots.
+	  Initially the MPSL timeslot is requested with normal priority. After
+	  timeout specified by this Kconfig option, higher timeslot priority
+	  is used to increase priority of the flash operation.
+
 config SOC_FLASH_NRF_RADIO_SYNC_RPC_CONTROLLER
 	bool "Nordic nRFx flash driver RPC synchronization controller"
 	default y if SOC_FLASH_NRF_RADIO_SYNC_RPC

--- a/drivers/mpsl/flash_sync/flash_sync_mpsl.c
+++ b/drivers/mpsl/flash_sync/flash_sync_mpsl.c
@@ -35,7 +35,8 @@ LOG_MODULE_REGISTER(flash_sync_mpsl);
 #define FLASH_OP_ONGOING_NONBLOCKING 0x266641F
 
 /* After this many us's, start using higher priority when requesting. */
-#define TIMESLOT_TIMEOUT_PRIORITY_NORMAL_US 30000
+#define TIMESLOT_TIMEOUT_PRIORITY_NORMAL_US \
+	CONFIG_SOC_FLASH_NRF_RADIO_SYNC_MPSL_NORMAL_PRIORITY_TIMEOUT_US
 
 struct mpsl_context {
 	/* This semaphore is taken with a timeout when the flash operation starts. */


### PR DESCRIPTION
Change introduces a Kconfig option that can be used to configure timeout for normal priority MPSL request (after the timeout specified by this Kconfig option, higher timeslot priority is used to increase priority of the FLASH operation).

PR also reduces the timeout for normal priority MPSL request for nRF Desktop application to speed up NVM operations.

Jira: NCSDK-36118